### PR TITLE
Fixed bug where it tried to store name as email address

### DIFF
--- a/src/components/Slack/Slack.js
+++ b/src/components/Slack/Slack.js
@@ -120,9 +120,9 @@ const Slack = () => {
             placeholder="First Name"
             autoComplete="off"
             ref={(node) => {
-              emailInput = handleInputRef(node, data);
+              nameInput = handleInputRef(node, data);
 
-              return emailInput;
+              return nameInput;
             }}
           />
         </label>


### PR DESCRIPTION
I think I found and fixed a small bug that was making it impossible to send a request to join the FCC Slack channel. The input element for "name" was handling the input as if it were an email address instead, generating this error:

```
Uncaught TypeError: Cannot read property 'value' of undefined
    at onSubmit (Slack.js:93)
```

Note that if you try to send multiple invite requests without reloading (which wouldn't be normal user behavior anyway), you get this error:

```
TypeError: Cannot set property 'value' of null
handleInputRef
src/components/Slack/Slack.js:13
```

I might try to fix that later, but it seems like the basic functionality of getting one Slack invite is restored.